### PR TITLE
Add SorWiki to the webring

### DIFF
--- a/webring.txt
+++ b/webring.txt
@@ -62,5 +62,4 @@ https://basementcommunity.com
 https://unmappedworlds.com
 https://trendingnow.games/
 https://www.gameboymuseum.com/
-
 https://sorwiki.com/

--- a/webring.txt
+++ b/webring.txt
@@ -62,3 +62,5 @@ https://basementcommunity.com
 https://unmappedworlds.com
 https://trendingnow.games/
 https://www.gameboymuseum.com/
+
+https://sorwiki.com/


### PR DESCRIPTION
SorWiki is an independent, actively maintained Sea of Remnants wiki with character and equipment data, guides, and player tools. A link back to VGW is live at https://sorwiki.com/en/partners/.